### PR TITLE
Fix Crypto stock returns

### DIFF
--- a/yahoo_finance_async/api.py
+++ b/yahoo_finance_async/api.py
@@ -123,7 +123,6 @@ class OHLC:
                     f"Yahoo Finance API responded with a specific error - {errors}"
                 )
             result = response["chart"]["result"][0]
-
             meta = result["meta"]
 
             # Convert timestamps to datetimes
@@ -153,6 +152,9 @@ class OHLC:
                     }
                 )
 
+            return candles, meta
+
+        except TypeError as e:
             return candles, meta
 
         except Exception as e:


### PR DESCRIPTION
API returns from Yahoo on CryptoCurrencies (BTC-USD, DOGE-USD, etc)
are empty in their last list element. This caused parse_ohlc to
error when attempting to float a NoneType.

By catching these TypeErrors, we can still return the last candle
data and metadata in the event that todays OHLC data is None